### PR TITLE
Changed Karelian mentions to Viena Karelian for clarity

### DIFF
--- a/.gut/delta.toml
+++ b/.gut/delta.toml
@@ -5,5 +5,5 @@ template_sha = "4712e7cbb43166fccf1100b5e6791c0f3de2f261"
 [replacements]
 __REPO__ = "lang-krl"
 __UND2C__ = "krl"
-__UNDEFINED__ = "Karelian"
+__UNDEFINED__ = "Viena Karelian"
 __UND__ = "krl"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -27,7 +27,7 @@ identifiers:
     type: url
     value: https://aclanthology.org/2022.lrec-1.125/
 keywords:
-  - Karelian
+  - Viena Karelian
   - NLP
   - morphology
   - spell-checking

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-The Karelian morphology and tools
+The Viena Karelian morphology and tools
 =================================
 
 [![Maturity](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fgiellalt%2Flang-krl%2Fgh-pages%2Fmaturity.json)](https://giellalt.github.io/MaturityClassification.html)
@@ -16,7 +16,7 @@ Download nightly / CI/CD installation packages for testing (contains the core zh
 
 __NB!!__ Note that the nightly / CI/CD installation packages are not tested for language quality, and might contain regressions and errors.
 
-This directory contains source files for the Karelian language
+This directory contains source files for the Viena Karelian language
 morphology and dictionary. The data and implementation are licenced
 under GNU GPLv3 licence also detailed in the
 [LICENSE](https://github.com/giellalt/lang-krl/blob/main/LICENSE). The
@@ -24,7 +24,7 @@ authors named in the AUTHORS file are available to grant
 other licencing choices.
 
 Install proofing tools and [keyboards](https://github.com/giellalt/keyboard-krl)
-for the Karelian language by using the [Divvun Installer](http://divvun.no)
+for the Viena Karelian language by using the [Divvun Installer](http://divvun.no)
 
 Download and test speller files
 -------------------------------
@@ -64,7 +64,7 @@ Lexical data was taken from:
 Core dependencies
 -----------------
 
-In order to compile and use the Karelian language morphology and
+In order to compile and use the Viena Karelian language morphology and
 dictionaries, you need:
 
 - an FST compiler: [HFST](https://github.com/hfst/hfst), [Foma](https://github.com/mhulden/foma) or [Xerox Xfst](https://web.stanford.edu/~laurik/fsmbook/home.html)

--- a/configure.ac
+++ b/configure.ac
@@ -52,7 +52,7 @@ AC_SUBST([GLANG2], [krl])
 AC_SUBST([GTLANG2], $GLANG2)
 # GLANGUAGE is the full language name as given by the ISO 639-3 file.
 # GTLANGUAGE is deprecated, defined for backwards compatibility.
-AC_SUBST([GLANGUAGE], ["Karelian"])
+AC_SUBST([GLANGUAGE], ["Viena Karelian"])
 AC_SUBST([GTLANGUAGE], $GLANGUAGE)
 
 ### Speller release version (usually different from the package version,

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,5 +1,5 @@
 theme: jekyll-theme-minimal
-title: Karelian NLP Grammar
+title: Viena Karelian NLP Grammar
 description: Finite state and Constraint Grammar based analysers, proofing tools and other resources
 plugins:
   - jemoji

--- a/docs/index-header.md
+++ b/docs/index-header.md
@@ -1,4 +1,4 @@
-# Karelian documentation
+# Viena Karelian documentation
 
 [![Maturity](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fgiellalt%2Flang-krl%2Fgh-pages%2Fmaturity.json)](https://giellalt.github.io/MaturityClassification.html)
 ![Lemma count](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fgiellalt%2Flang-krl%2Fgh-pages%2Flemmacount.json)
@@ -6,7 +6,7 @@
 [![Issues](https://img.shields.io/github/issues/giellalt/lang-krl)](https://github.com/giellalt/lang-krl/issues)
 [![Build Status](https://divvun-tc.giellalt.org/api/github/v1/repository/giellalt/lang-krl/main/badge.svg)](https://github.com/giellalt/lang-krl/actions)
 
-These pages document the work on the [Karelian language model](https://github.com/giellalt/lang-krl). 
+These pages document the work on the [Viena Karelian language model](https://github.com/giellalt/lang-krl). 
 
 The analyser contains appr. 64000 stems, but there still are some
 grammatical issues to solve before the coverage is good.

--- a/giella-krl.pc.in
+++ b/giella-krl.pc.in
@@ -6,6 +6,6 @@ dir=${datadir}/giella/${gtlang}
 srcdir=${datadir}/giella/${gtlang}
 
 Name: giella-krl
-Description: Finite-state language processing tools for Karelian
+Description: Finite-state language processing tools for Viena Karelian
 URL: https://giellalt.uit.no/index.html
 Version: @VERSION@

--- a/manifest.toml
+++ b/manifest.toml
@@ -1,17 +1,17 @@
-spellername = "Karelian"
+spellername = "Viena Karelian"
 spellerversion = "0.1.1"
 
 # Name of the speller package in various languages.
 # The default is English + autonym:
 [speller.name]
-en = "Karelian spellchecker"
+en = "Viena Karelian spellchecker"
 krl = "Autonym spellchecker"
 
 # Description of the speller package in various languages.
 # The default is English + autonym:
 [speller.description]
-en = "A spellchecker for Karelian, made by members of the language community, and by the Divvun and Giellatekno groups at UiT The Arctic University of Norway"
-krl = "TRANSLATE: A spellchecker for Karelian, made by members of the language community, and by the Divvun and Giellatekno groups at UiT The Arctic University of Norway"
+en = "A spellchecker for Viena Karelian, made by members of the language community, and by the Divvun and Giellatekno groups at UiT The Arctic University of Norway"
+krl = "TRANSLATE: A spellchecker for Viena Karelian, made by members of the language community, and by the Divvun and Giellatekno groups at UiT The Arctic University of Norway"
 
 [macos]
 system_pkg_id = "no.divvun.MacDivvun.krl"

--- a/src/fst/morphology/affixes/adjectives.lexc
+++ b/src/fst/morphology/affixes/adjectives.lexc
@@ -1,6 +1,6 @@
 !! Adjective inflection
 !  --------------------
-!! The Karelian language adjectives compare.
+!! The Viena Karelian language adjectives compare.
 
 LEXICON adjective
 +A: # ;

--- a/src/fst/morphology/affixes/nouns.lexc
+++ b/src/fst/morphology/affixes/nouns.lexc
@@ -1,6 +1,6 @@
 !! # Noun inflection
 !  ---------------
-!! This file documents Karelian noun inflection.
+!! This file documents Viena Karelian noun inflection.
 
 
 

--- a/src/fst/morphology/affixes/prefixes.lexc
+++ b/src/fst/morphology/affixes/prefixes.lexc
@@ -1,6 +1,6 @@
 !! Prefixes
 !  --------
-!! Prefixes in the Karelian language are bound to beginning of other words.
+!! Prefixes in the Viena Karelian language are bound to beginning of other words.
 
 
 

--- a/src/fst/morphology/affixes/propernouns.lexc
+++ b/src/fst/morphology/affixes/propernouns.lexc
@@ -1,6 +1,6 @@
 !! Proper noun inflection
 !  ----------------------
-!! The Karelian language proper nouns inflect in the same cases as regular
+!! The Viena Karelian language proper nouns inflect in the same cases as regular
 !! nouns, but 
 
 

--- a/src/fst/morphology/affixes/verbs.lexc
+++ b/src/fst/morphology/affixes/verbs.lexc
@@ -1,4 +1,4 @@
-!! # Karelian Verb inflection
+!! # Viena Karelian Verb inflection
 !  ---------------
 !! The verb lexicon contains two groups of continuation lexica
 !! One, with names like VERB_KUUL/UO (in capital letters and indicating stem)

--- a/src/fst/morphology/phonology.twolc
+++ b/src/fst/morphology/phonology.twolc
@@ -1,5 +1,5 @@
 ! =================================== !
-!! # The Karelian morphophonological/twolc rules file 
+!! # The Viena Karelian morphophonological/twolc rules file 
 ! =================================== !
 
 !! This file documents the [phonology.twolc file](http://github.com/giellalt/lang-krl/blob/main/src/fst/phonology.twolc) 

--- a/src/fst/morphology/root.lexc
+++ b/src/fst/morphology/root.lexc
@@ -1,4 +1,4 @@
-! Divvun & Giellatekno - open source grammars for Karelian language
+! Divvun & Giellatekno - open source grammars for Viena Karelian language
 ! Copyright © 2015 The University of Tromsø & the Norwegian Sámi Parliament
 ! http://giellatekno.uit.no & http://divvun.no
 !
@@ -13,10 +13,10 @@
 ! giellatekno@uit.no or feedback@divvun.no
 
 ! ========================================================================== !
-!! #         Karelian morphological analyser                      
+!! #         Viena Karelian morphological analyser                      
 ! ========================================================================== !
 
-!! This file documents the Karelian [fst/root.lexc file](https://github.com/giellalt/lang-krl/blob/main/src/fst/root.lexc)
+!! This file documents the Viena Karelian [fst/root.lexc file](https://github.com/giellalt/lang-krl/blob/main/src/fst/root.lexc)
  
 
 !! ## Tags and other multicharacter symbols
@@ -25,7 +25,7 @@ Multichar_Symbols  !!≈ # Definitions for @CODE@
 
 !! ## Analysis symbols
 !  ----------------
-!! The morphological analyses of wordforms for the Karelian
+!! The morphological analyses of wordforms for the Viena Karelian
 !! language are presented in this system in terms of the following symbols.
 !! (It is highly suggested to follow existing standards when adding new tags).
 
@@ -417,7 +417,7 @@ Multichar_Symbols  !!≈ # Definitions for @CODE@
 !! ## The Root and K lexica
 LEXICON Root
 !! **LEXICON @LEXNAME@** is where it all begins
-!! The word forms in Karelian language start from the lexeme roots of basic
+!! The word forms in Viena Karelian language start from the lexeme roots of basic
 !! word classes, or optionally from prefixes:
    Nouns       ;  !!≈ * @CODE@
    Verbs       ;  !!≈ * @CODE@

--- a/src/fst/morphology/stems/adjectives.lexc
+++ b/src/fst/morphology/stems/adjectives.lexc
@@ -1,4 +1,4 @@
-!! # Karelian Adjectives
+!! # Viena Karelian Adjectives
 !  ----------
 !! This file documents the `stems/adjectives.lexc` file for Adjective stems 
 !! The files points to the `affixes/adjectives.lexc` file.

--- a/src/fst/morphology/stems/adpositions.lexc
+++ b/src/fst/morphology/stems/adpositions.lexc
@@ -1,4 +1,4 @@
-!! # Karelian adpositions
+!! # Viena Karelian adpositions
 
 LEXICON adpositions
 !! @LEXNAME@

--- a/src/fst/morphology/stems/adverbs.lexc
+++ b/src/fst/morphology/stems/adverbs.lexc
@@ -1,4 +1,4 @@
-!! # Karelian adverb stems
+!! # Viena Karelian adverb stems
 
 LEXICON ADV
 !! @LEXNAME@

--- a/src/fst/morphology/stems/conjunctions.lexc
+++ b/src/fst/morphology/stems/conjunctions.lexc
@@ -1,4 +1,4 @@
-!! # Karelian conjunctions
+!! # Viena Karelian conjunctions
 
 LEXICON conjunctions
 !! @LEXNAME@

--- a/src/fst/morphology/stems/interjections.lexc
+++ b/src/fst/morphology/stems/interjections.lexc
@@ -1,4 +1,4 @@
-!! # Karelian interjections
+!! # Viena Karelian interjections
 
 LEXICON interjections
 !! @LEXNAME*

--- a/src/fst/morphology/stems/nouns.lexc
+++ b/src/fst/morphology/stems/nouns.lexc
@@ -1,6 +1,6 @@
-!! # Karelian Nouns
+!! # Viena Karelian Nouns
 ! -----
-!! This file documents the Karelian noun stem file.
+!! This file documents the Viena Karelian noun stem file.
 !! The first part of the file contains stems, the second contains the 
 !! intermediate morphology.
 

--- a/src/fst/morphology/stems/particles.lexc
+++ b/src/fst/morphology/stems/particles.lexc
@@ -1,4 +1,4 @@
-!! # Karelian particles
+!! # Viena Karelian particles
 
 LEXICON Particles
 !! **LEXICON @LEXNAME@** gives the particles.

--- a/src/fst/morphology/stems/pronouns.lexc
+++ b/src/fst/morphology/stems/pronouns.lexc
@@ -1,4 +1,4 @@
-!! # Karelian Pronouns
+!! # Viena Karelian Pronouns
 !  --------
 !! The file list pronoun stems .
 

--- a/src/fst/morphology/stems/propernouns.lexc
+++ b/src/fst/morphology/stems/propernouns.lexc
@@ -1,4 +1,4 @@
-!! # Karelian Propernouns
+!! # Viena Karelian Propernouns
 
 !! The file `stems/propernouns.lexc` lists just that.
  

--- a/src/fst/morphology/stems/verbs.lexc
+++ b/src/fst/morphology/stems/verbs.lexc
@@ -1,4 +1,4 @@
-!! # Documenting the Karelian Verb lexicon.
+!! # Documenting the Viena Karelian Verb lexicon.
 !  -----
 
 !! The verb lexicon contains two groups of continuation lexica

--- a/src/fst/transcriptions/transcriptor-abbrevs2text.lexc
+++ b/src/fst/transcriptions/transcriptor-abbrevs2text.lexc
@@ -1,4 +1,4 @@
-! Divvun & Giellatekno - open source grammars for Karelian language
+! Divvun & Giellatekno - open source grammars for Viena Karelian language
 ! Copyright © 2021 The University of Tromsø & the Norwegian Sámi Parliament
 ! http://giellatekno.uit.no & http://divvun.no
 !
@@ -18,10 +18,10 @@
 ! to work.
 
 ! ========================================================================== !
-! !!            !!!Karelian abbreviations                               !
+! !!            !!!Viena Karelian abbreviations                               !
 ! ========================================================================== !
 
-!! We describe here how abbreviations are in Karelian are read out, e.g.
+!! We describe here how abbreviations in Viena Karelian are read out, e.g.
 !! for text-to-speech systems.
 
 LEXICON Root

--- a/src/fst/transcriptions/transcriptor-abbrevs2text.lexc
+++ b/src/fst/transcriptions/transcriptor-abbrevs2text.lexc
@@ -18,10 +18,10 @@
 ! to work.
 
 ! ========================================================================== !
-! !!            !!!Viena Karelian abbreviations                               !
+! !!            !!!Viena Karelian abbreviations                              !
 ! ========================================================================== !
 
-!! We describe here how abbreviations in Viena Karelian are read out, e.g.
+!! We describe here how abbreviations are in Viena Karelian are read out, e.g.
 !! for text-to-speech systems.
 
 LEXICON Root

--- a/tools/grammarcheckers/index.xml
+++ b/tools/grammarcheckers/index.xml
@@ -2,7 +2,7 @@
 <hfstspeller dtdversion="1.0" hfstversion="3">
   <info>
     <locale>krl</locale>
-    <title>Karelian Speller</title>
+    <title>Viena Karelian Speller</title>
     <description>This speller is used in conjunction with the grammar checker,
     and is only used as part of the development cycle. The main feature is that
     the acceptor is a full analyser, to feed into the CG stream.</description>
@@ -12,7 +12,7 @@
     <contact email="feedback@divvun.no" website="http://divvun.no"/>
   </info>
   <acceptor type="general" id="acceptor.default.hfst">
-    <title>Karelian analysing speller</title>
+    <title>Viena Karelian analysing speller</title>
     <description>Speller lexicon with analysis output.</description>
   </acceptor>
   <errmodel id="errmodel.default.hfst">

--- a/tools/mt/apertium/tagsets/README.txt
+++ b/tools/mt/apertium/tagsets/README.txt
@@ -15,7 +15,7 @@ modify-rags.TARGETLANG.regex - pair-specific changes using regex, manually m.
 apertium.TARGETLANG.relabel  - pair-specific relabelling, manually add/maint.
 
 Replace TARGETLANG with the language code of the actual target language you
-are building your Karelian apertium analyser for.
+are building your Viena Karelian apertium analyser for.
 
 
 The file apertium.postproc.relabel is added to all languages and contain some


### PR DESCRIPTION
I changed `Karelian` to `Viena Karelian`. GT has two Karelian dialects, Viena and Livvi Karelian. One not having the dialect specified is confusing.